### PR TITLE
TryLookup renamed to TryResolve for consistency with FormLink

### DIFF
--- a/SilentMoonsEnchantmentPatcher/Program.cs
+++ b/SilentMoonsEnchantmentPatcher/Program.cs
@@ -1,4 +1,4 @@
-﻿// /*
+// /*
 //     Copyright (C) 2020  erri120
 // 
 //     This program is free software: you can redistribute it and/or modify
@@ -191,7 +191,7 @@ namespace SilentMoonsEnchantmentPatcher
 
         private static List<WeaponDamageLevel> GetWeaponDamageLevel(FormKey formKey, ILinkCache linkCache)
         {
-            if (!linkCache.TryLookup<ILeveledItemGetter>(formKey, out var leveledItem)) 
+            if (!linkCache.TryResolve<ILeveledItemGetter>(formKey, out var leveledItem)) 
                 return new List<WeaponDamageLevel>();
             if (leveledItem.Entries == null) 
                 return new List<WeaponDamageLevel>();
@@ -400,13 +400,13 @@ namespace SilentMoonsEnchantmentPatcher
             if (!state.LoadOrder.TryGetValue(DawnguardModKey, out IModListing<ISkyrimModGetter>? dawnguardListing))
                 throw new ArgumentException("Dawnguard.esm was not found!");
             
-            if (!state.LinkCache.TryLookup<IFormListGetter>(LunarForgeUnenchantedFormIDListFormKey, out var unenchantedFormIDListGetter))
+            if (!state.LinkCache.TryResolve<IFormListGetter>(LunarForgeUnenchantedFormIDListFormKey, out var unenchantedFormIDListGetter))
                 throw new Exception($"Unable to find {LunarForgeUnenchantedFormIDListFormKey}");
-            if (!state.LinkCache.TryLookup<IFormListGetter>(LunarForgeAwakenedLunarFormIDListFormKey, out var awakenedFormIDListGetter))
+            if (!state.LinkCache.TryResolve<IFormListGetter>(LunarForgeAwakenedLunarFormIDListFormKey, out var awakenedFormIDListGetter))
                 throw new Exception($"Unable to find {LunarForgeAwakenedLunarFormIDListFormKey}");
-            if (!state.LinkCache.TryLookup<IFormListGetter>(LunarForgeLunarAbsorbFormIDListFormKey, out var lunarAbsorbFormIDListGetter))
+            if (!state.LinkCache.TryResolve<IFormListGetter>(LunarForgeLunarAbsorbFormIDListFormKey, out var lunarAbsorbFormIDListGetter))
                 throw new Exception($"Unable to find {LunarForgeLunarAbsorbFormIDListFormKey}");
-            if (!state.LinkCache.TryLookup<IFormListGetter>(LunarForgeLunarBasicFormIDListFormKey, out var lunarBasicFormIDListGetter))
+            if (!state.LinkCache.TryResolve<IFormListGetter>(LunarForgeLunarBasicFormIDListFormKey, out var lunarBasicFormIDListGetter))
                 throw new Exception($"Unable to find {LunarForgeLunarBasicFormIDListFormKey}");
 
             IReadOnlyDictionary<string, List<EnchantmentData>> enchantments = GetEnchantmentsData(sailorMoonMod.Mod!, lunarEnchantmentData);
@@ -441,7 +441,7 @@ namespace SilentMoonsEnchantmentPatcher
                 {
                     //filter recipes that create un-enchanted weapons at forges
                     if (constructibleObject.CreatedObject.FormKey == null
-                        || !state.LinkCache.TryLookup<IWeaponGetter>(constructibleObject.CreatedObject.FormKey.Value, out var createdObject))
+                        || !constructibleObject.CreatedObject.TryResolve<IWeaponGetter>(state.LinkCache, out var createdObject))
                     {
                         return null;
                     }

--- a/SilentMoonsEnchantmentPatcher/SilentMoonsEnchantmentPatcher.csproj
+++ b/SilentMoonsEnchantmentPatcher/SilentMoonsEnchantmentPatcher.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Mutagen.Bethesda.Core" Version="0.21.2" />
+      <PackageReference Include="Mutagen.Bethesda.Core" Version="0.22.0" />
       <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-      <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.21.2" />
-      <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.10.18" />
+      <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.22.0" />
+      <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.12.0" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Also swapped the resolution of CreatedObject FormLink to originate off the link, as that API was added to be able to scope to IWeaponGetter from there