### PR TITLE
Api

### DIFF
--- a/SilentMoonsEnchantmentPatcher/Program.cs
+++ b/SilentMoonsEnchantmentPatcher/Program.cs
@@ -24,7 +24,6 @@ using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Synthesis;
 using Mutagen.Bethesda.FormKeys.SkyrimSE;
 using Noggog;
-using Wabbajack.Common;
 
 namespace SilentMoonsEnchantmentPatcher
 {
@@ -197,7 +196,7 @@ namespace SilentMoonsEnchantmentPatcher
                 return new List<WeaponDamageLevel>();
             List<ILeveledItemEntryGetter> entries = leveledItem.Entries
                 .Where(x => x.Data != null)
-                .DistinctBy(x => x.Data!.Reference)
+                .Distinct(x => x.Data!.Reference)
                 .ToList();
             var minLevel = entries.Min(x => x.Data!.Level);
             List<WeaponDamageLevel> result = entries.Select(x =>

--- a/SilentMoonsEnchantmentPatcher/SilentMoonsEnchantmentPatcher.csproj
+++ b/SilentMoonsEnchantmentPatcher/SilentMoonsEnchantmentPatcher.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Mutagen.Bethesda.Core" Version="0.22.0" />
+      <PackageReference Include="Mutagen.Bethesda.Core" Version="0.25.0" />
       <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-      <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.22.0" />
-      <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.12.0" />
+      <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.25.0" />
+      <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.13.2" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
Wabbajack.Common won't be implicitly imported in the upcoming Mutagen version, so this is just prep.

Was only being used for one `DistinctBy` extension method, so I just swapped that one out for a similar one from CSharpExt